### PR TITLE
Use ArrayList rather than LinkedList as backing for immutable lists.

### DIFF
--- a/src/main/java/bpsm/edn/parser/DefaultListFactory.java
+++ b/src/main/java/bpsm/edn/parser/DefaultListFactory.java
@@ -1,12 +1,12 @@
 package bpsm.edn.parser;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 
 final class DefaultListFactory implements BuilderFactory {
     public CollectionBuilder builder() {
         return new CollectionBuilder() {
-            LinkedList<Object> list = new LinkedList<Object>();
+            ArrayList<Object> list = new ArrayList<Object>();
             public void add(Object o) {
                 list.add(o);
             }


### PR DESCRIPTION
ArrayList should be better than LinkedList for random access and iteration once the unmodifiable version is returned.
