### PR TITLE
Simplify the Printer interface by removing the close() operation. 

### DIFF
--- a/src/main/java/bpsm/edn/printer/Printer.java
+++ b/src/main/java/bpsm/edn/printer/Printer.java
@@ -9,7 +9,6 @@ public interface Printer {
     Printer append(CharSequence csq);
     Printer append(char c);
     Printer softspace();
-    void close();
 
     public interface Config {
 

--- a/src/main/java/bpsm/edn/printer/Printers.java
+++ b/src/main/java/bpsm/edn/printer/Printers.java
@@ -149,7 +149,7 @@ public class Printers {
 
     public static String printString(Printer.Config cfg, Object ednValue) {
         StringBuilder sb = new StringBuilder();
-        newPrinter(cfg, sb).printValue(ednValue).close();
+        newPrinter(cfg, sb).printValue(ednValue);
         return sb.toString();
     }
 

--- a/src/test/java/bpsm/edn/examples/CustomTagPrinter.java
+++ b/src/test/java/bpsm/edn/examples/CustomTagPrinter.java
@@ -26,7 +26,7 @@ public class CustomTagPrinter {
             .build();
         Printer p = Printers.newPrinter(cfg, w);
         p.printValue(URI.create("http://example.com"));
-        p.close();
+        w.close();
         assertEquals("#bpsm/uri\"http://example.com\"", w.toString());
     }
 }

--- a/src/test/java/bpsm/edn/printer/PrinterTest.java
+++ b/src/test/java/bpsm/edn/printer/PrinterTest.java
@@ -69,7 +69,6 @@ public class PrinterTest {
         StringWriter sw = new StringWriter();
         Printer ew = Printers.newPrinter(Printers.defaultPrinterConfig(), sw);
         ew.printValue(originalParsedValue);
-        ew.close();
 
         parser = Parsers.newParser(Parsers.defaultConfiguration(), new StringReader(sw.toString()));
         Object secondGenerationParsedValue = parser.nextValue();


### PR DESCRIPTION
This is not needed in general, and where it is needed then the caller should
take care of closing the underlying Writer (see the CustomTagPrinter test for an example of this usage)
