### PR TITLE
Allow Symbols to contain $ % & =

### DIFF
--- a/src/main/java/us/bpsm/edn/util/CharClassify.java
+++ b/src/main/java/us/bpsm/edn/util/CharClassify.java
@@ -65,7 +65,7 @@ public class CharClassify {
     static {
         SYMBOL_START = new BitSet(128);
         SYMBOL_START.or(LETTER);
-        for (char c: "!*+-./?_".toCharArray()) {
+        for (char c: "!*+-./?_$%&=".toCharArray()) {
             SYMBOL_START.set(c);
         }
     }


### PR DESCRIPTION
As per the [EDN spec](https://github.com/edn-format/edn/blob/master/README.md#symbols):

> Symbols begin with a non-numeric character and can contain alphanumeric characters and . \* + ! - _ ? $ % & =.
