### PR TITLE
Fixes a problem with softspaces around maps/sequences/strings

### DIFF
--- a/src/main/java/us/bpsm/edn/printer/Printers.java
+++ b/src/main/java/us/bpsm/edn/printer/Printers.java
@@ -1,20 +1,6 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn.printer;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.io.Closeable;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.Map;
-import java.util.RandomAccess;
-import java.util.Set;
-import java.util.UUID;
-
 import us.bpsm.edn.EdnException;
 import us.bpsm.edn.EdnIOException;
 import us.bpsm.edn.Keyword;
@@ -26,6 +12,19 @@ import us.bpsm.edn.parser.Parser;
 import us.bpsm.edn.protocols.Protocol;
 import us.bpsm.edn.protocols.Protocols;
 import us.bpsm.edn.util.CharClassify;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.UUID;
 
 
 /**
@@ -245,11 +244,11 @@ public class Printers {
             @Override
             public void eval(List<?> self, Printer writer) {
                 boolean vec = self instanceof RandomAccess;
-                writer.append(vec ? '[' : '(');
+                writer.softspace().append(vec ? '[' : '(');
                 for (Object o: self) {
                     writer.printValue(o);
                 }
-                writer.append(vec ? ']' : ')');
+                writer.append(vec ? ']' : ')').softspace();
             }
         };
     }
@@ -271,12 +270,12 @@ public class Printers {
         return new Printer.Fn<Map<?,?>>() {
             @Override
             public void eval(Map<?,?> self, Printer writer) {
-                writer.append('{');
+                writer.softspace().append('{');
                 for (Map.Entry<?,?> p: self.entrySet()) {
                     writer.printValue(p.getKey())
                     .printValue(p.getValue());
                 }
-                writer.append('}');
+                writer.append('}').softspace();
             }
         };
     }
@@ -323,7 +322,7 @@ public class Printers {
         return new Printer.Fn<CharSequence>() {
             @Override
             public void eval(CharSequence self, Printer writer) {
-                writer.append('"');
+                writer.softspace().append('"');
                 for (int i = 0; i < self.length(); i++) {
                     final char c = self.charAt(i);
                     switch (c) {
@@ -352,7 +351,7 @@ public class Printers {
                         writer.append(c);
                     }
                 }
-                writer.append('"');
+                writer.append('"').softspace();
             }
         };
     }

--- a/src/test/java/us/bpsm/edn/printer/PrinterTest.java
+++ b/src/test/java/us/bpsm/edn/printer/PrinterTest.java
@@ -1,18 +1,18 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn.printer;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.StringWriter;
-import java.util.ArrayList;
-
 import org.junit.Test;
-
+import us.bpsm.edn.Keyword;
 import us.bpsm.edn.parser.Parseable;
 import us.bpsm.edn.parser.Parser;
 import us.bpsm.edn.parser.Parsers;
-import us.bpsm.edn.printer.Printer;
-import us.bpsm.edn.printer.Printers;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 
 public class PrinterTest {
@@ -47,6 +47,8 @@ public class PrinterTest {
     public void testComplexValue() {
         assertRoundTrip("{:foo [1 2.0 19023847928034709821374012938749N 91821234112347634.128937467E-3M]\n"
                 + " :bar/baz #{true false nil}\n"
+                + " :bar/bazinga [:test \"test\"]\n"
+                + " :nested [:test :something :else {:test 1} :otherwise :that]\n"
                 + " / (\"abc\\tdef\\n\" #uuid \"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\")\n"
                 + " \\formfeed [#inst \"2010\", #inst \"2010-11\", #inst \"2010-11-12T09:08:07.123+02:00\"]\n"
                 + " :omega [a b c d \\a\\b\\c#{}]}");
@@ -62,6 +64,22 @@ public class PrinterTest {
         al.add(2);
         p.printValue(al);
         assertEquals("[1 2]", sw.toString());
+    }
+
+    @Test
+    public void testSoftspaces() {
+        StringWriter sw = new StringWriter();
+        Printer p = Printers.newPrinter(sw);
+
+        ArrayList<Object> al = new ArrayList<Object>();
+        al.add(Keyword.newKeyword("test"));
+        al.add("test");
+        al.add(Keyword.newKeyword("value"));
+        Map map = new HashMap();
+        map.put(Keyword.newKeyword("name"), "Test");
+        al.add(map);
+        p.printValue(al);
+        assertEquals("[:test \"test\" :value {:name \"Test\"}]", sw.toString());
     }
 
     void assertRoundTrip(String ednText) {


### PR DESCRIPTION
When writing out some Java structures to EDN I found that not everything was correctly adding in softspaces, such that the following output was being generated:

```
{:operation :search :options{:timeout-ms 2000 :max-index-scans 2}:scopes[:cust-ref "xxx"]}
```

Whilst this parses, it doesn't look very nice when trying to diagnose other problems.
