### PR TITLE
Teach default edn parser to produce values that can be serialized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.10.1</version>
         <configuration>
           <show>protected</show>
           <nohelp>true</nohelp>
+          <debug>true</debug>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/us/bpsm/edn/Keyword.java
+++ b/src/main/java/us/bpsm/edn/Keyword.java
@@ -10,7 +10,7 @@ import static us.bpsm.edn.Symbol.newSymbol;
  * <p>
  * Note: Keywords print with a leading colon, but this is not part of the
  * keyword's name:
- * 
+ *
  * <pre>
  * {@code // For the keyword ":foo/bar"
  * Keyword k = newKeyword("foo", "bar");
@@ -41,7 +41,7 @@ public final class Keyword implements Named, Comparable<Keyword> {
      * <p>
      * Keywords are interned, which means that any two keywords which are equal
      * (by value) will also be identical (by reference).
-     * 
+     *
      * @param prefix
      *            An empty String or a non-empty String obeying the restrictions
      *            specified by edn. Never null.
@@ -56,7 +56,7 @@ public final class Keyword implements Named, Comparable<Keyword> {
 
     /**
      * This is equivalent to {@code newKeyword("", name)}.
-     * 
+     *
      * @param name
      *            A non-empty string obeying the restrictions specified by edn.
      *            Never null.
@@ -70,7 +70,6 @@ public final class Keyword implements Named, Comparable<Keyword> {
     /**
      * Return a Keyword with the same prefix and name as {@code sym}.
      * @param sym a Symbol, never null
-     * @return a Keyword with the same prefix and name as {@code sym}.
      */
     private Keyword(Symbol sym) {
         if (sym == null) {

--- a/src/main/java/us/bpsm/edn/Keyword.java
+++ b/src/main/java/us/bpsm/edn/Keyword.java
@@ -1,6 +1,11 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
 import static us.bpsm.edn.Symbol.newSymbol;
 
 /**
@@ -19,7 +24,7 @@ import static us.bpsm.edn.Symbol.newSymbol;
  * k.toString()  => ":foo/bar"}
  * </pre>
  */
-public final class Keyword implements Named, Comparable<Keyword> {
+public final class Keyword implements Named, Comparable<Keyword>, Serializable {
     private final Symbol sym;
 
     /** {@inheritDoc} */
@@ -91,4 +96,23 @@ public final class Keyword implements Named, Comparable<Keyword> {
 
     private static final Interner<Symbol, Keyword> INTERNER = new Interner<Symbol, Keyword>();
 
+    private Object writeReplace() {
+        return new SerializationProxy(sym);
+    }
+
+    private void readObject(ObjectInputStream stream)
+      throws InvalidObjectException {
+        throw new InvalidObjectException("only proxy can be serialized");
+    }
+
+    private static class SerializationProxy implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final Symbol sym;
+        private SerializationProxy(Symbol sym) {
+            this.sym = sym;
+        }
+        private Object readResolve() throws ObjectStreamException {
+            return newKeyword(sym);
+        }
+    }
 }

--- a/src/main/java/us/bpsm/edn/Symbol.java
+++ b/src/main/java/us/bpsm/edn/Symbol.java
@@ -5,12 +5,14 @@ import static us.bpsm.edn.util.CharClassify.isDigit;
 import static us.bpsm.edn.util.CharClassify.symbolStart;
 import us.bpsm.edn.util.CharClassify;
 
+import java.io.Serializable;
+
 /**
  * A Symbol is {@linkplain Named}. Additionally it obeys the syntactic
  * restrictions defined for
  * <a href="https://github.com/edn-format/edn#symbols">edn Symbols</a>.
  */
-public final class Symbol implements Named, Comparable<Symbol> {
+public final class Symbol implements Named, Comparable<Symbol>, Serializable {
 
     private final String prefix;
     private final String name;

--- a/src/main/java/us/bpsm/edn/Tag.java
+++ b/src/main/java/us/bpsm/edn/Tag.java
@@ -1,6 +1,8 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.Serializable;
+
 import static us.bpsm.edn.Symbol.newSymbol;
 
 /**
@@ -18,7 +20,7 @@ import static us.bpsm.edn.Symbol.newSymbol;
  * t.toString()  => "#foo/bar"}
  * </pre>
  */
-public final class Tag implements Named, Comparable<Tag> {
+public final class Tag implements Named, Comparable<Tag>, Serializable {
     private final Symbol sym;
 
     /** {@inheritDoc} */

--- a/src/main/java/us/bpsm/edn/TaggedValue.java
+++ b/src/main/java/us/bpsm/edn/TaggedValue.java
@@ -18,7 +18,7 @@ public final class TaggedValue {
      * Return a tagged value for the given tag and value (some edn data).
      * The tag must not be null.
      * @param tag not null.
-     * @param value
+     * @param value may be null.
      * @return a TaggedValue, never null.
      */
     public static TaggedValue newTaggedValue(Tag tag, Object value) {

--- a/src/main/java/us/bpsm/edn/TaggedValue.java
+++ b/src/main/java/us/bpsm/edn/TaggedValue.java
@@ -1,11 +1,13 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.Serializable;
+
 /**
  * A Tagged value that received no specific handling because the Parser
  * was not configured with a handler for its tag.
  */
-public final class TaggedValue {
+public final class TaggedValue implements Serializable {
     private final Tag tag;
     private final Object value;
 

--- a/src/main/java/us/bpsm/edn/parser/CollectionBuilder.java
+++ b/src/main/java/us/bpsm/edn/parser/CollectionBuilder.java
@@ -12,8 +12,12 @@ public interface CollectionBuilder {
      * map, this will be called an even number of times, first for a
      * key and then for its corresponding value until all key-value
      * pairs of the map have been added.
+     * <p>
+     * For other collections is can be called any number of times.
      *
      * <p>{@code add()} may not be called after {@code build()}.
+     * @param o an object to add to the collection under construction. o may
+     *          be null.
      */
     public void add(Object o);
 

--- a/src/main/java/us/bpsm/edn/parser/DefaultListFactory.java
+++ b/src/main/java/us/bpsm/edn/parser/DefaultListFactory.java
@@ -1,6 +1,7 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn.parser;
 
+import java.io.Serializable;
 import java.util.*;
 
 final class DefaultListFactory implements CollectionBuilder.Factory {
@@ -17,7 +18,7 @@ final class DefaultListFactory implements CollectionBuilder.Factory {
     }
 }
 
-final class DelegatingList<E> extends AbstractList<E> {
+final class DelegatingList<E> extends AbstractList<E> implements Serializable {
     final List<E> delegate;
 
     DelegatingList(List<E> delegate) {

--- a/src/main/java/us/bpsm/edn/parser/InstantToTimestamp.java
+++ b/src/main/java/us/bpsm/edn/parser/InstantToTimestamp.java
@@ -2,8 +2,8 @@
 package us.bpsm.edn.parser;
 
 /**
- * A Handler for {@code #inst} which translates the intant into a
- * {@link java.sql.TimeStamp}.
+ * A Handler for {@code #inst} which translates the instant into a
+ * {@link java.sql.Timestamp}.
  */
 public class InstantToTimestamp extends AbstractInstantHandler {
 

--- a/src/main/java/us/bpsm/edn/parser/InstantUtils.java
+++ b/src/main/java/us/bpsm/edn/parser/InstantUtils.java
@@ -16,7 +16,7 @@ public class InstantUtils {
 
     private static final Pattern INSTANT = Pattern.compile(
             "(\\d\\d\\d\\d)(?:-(\\d\\d)(?:-(\\d\\d)" +
-            "(?:[T](\\d\\d)(?::(\\d\\d)(?::(\\d\\d)(?:[.](\\d{1,9}))?)?)?)?)?)?" +
+                    "(?:[T](\\d\\d)(?::(\\d\\d)(?::(\\d\\d)(?:[.](\\d{1,9}))?)?)?)?)?)?" +
             "(?:[Z]|([-+])(\\d\\d):(\\d\\d))?");
 
     static ParsedInstant parse(String value) {
@@ -175,6 +175,7 @@ public class InstantUtils {
     /**
      * Return a String suitable for use as an edn {@code #inst}, given
      * a {@link GregorianCalendar}.
+     * @param cal must not be null.
      * @return an RFC3339 compatible string.
      */
     public static String calendarToString(GregorianCalendar cal) {
@@ -188,6 +189,7 @@ public class InstantUtils {
     /**
      * Return a String suitable for use as an edn {@code #inst}, given
      * a {@link Date}.
+     * @param date must not be null.
      * @return an RFC3339 compatible string.
      */
     public static String dateToString(Date date) {
@@ -204,11 +206,12 @@ public class InstantUtils {
     /**
      * Return a String suitable for use as an edn {@code #inst}, given
      * a {@link Timestamp}.
+     * @param ts must not be null.
      * @return an RFC3339 compatible string.
      */
     public static String timestampToString(Timestamp ts) {
         return TIMESTAMP_FORMAT.get().format(ts)
-             + String.format(".%09d-00:00", ts.getNanos());
+                + String.format(".%09d-00:00", ts.getNanos());
     }
 
     private static final ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT =

--- a/src/main/java/us/bpsm/edn/parser/Parseable.java
+++ b/src/main/java/us/bpsm/edn/parser/Parseable.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 
 /**
  * An edn {@link Parser} parses text from Objects implementing this
- * interface. The class {@link Parsers} provides facotry methods for
+ * interface. The class {@link Parsers} provides factory methods for
  * this type.
  */
 public interface Parseable extends Closeable {
@@ -19,6 +19,9 @@ public interface Parseable extends Closeable {
     /**
      * Read and return the next character from this Parseable as a
      * non-negative integer, or {@link #END_OF_INPUT}.
+     * @return a non-negative integer or {@link #END_OF_INPUT}
+     * @throws IOException when we're unexpectedly unable to read the next
+     *         character.
      */
     public int read() throws IOException;
 
@@ -34,6 +37,9 @@ public interface Parseable extends Closeable {
      * undefined. The behavior of calling {@code unread(ch)} more than
      * once without an intervening call to {@code read()} is
      * undefined.
+     * @param ch as returned by the previous call to {@code read()}.
+     * @throws IOException  when we're unexpectedly unable to push back the
+     *         given character.
      */
     public void unread(int ch) throws IOException;
 }

--- a/src/main/java/us/bpsm/edn/parser/Parser.java
+++ b/src/main/java/us/bpsm/edn/parser/Parser.java
@@ -2,6 +2,8 @@
 package us.bpsm.edn.parser;
 
 import static us.bpsm.edn.Tag.newTag;
+import us.bpsm.edn.EdnIOException;
+import us.bpsm.edn.EdnSyntaxException;
 import us.bpsm.edn.Tag;
 
 /**
@@ -9,7 +11,7 @@ import us.bpsm.edn.Tag;
  * Instances are constructed using factory methods in {@link Parsers}.
  *
  * <p>Any Parser can be shared freely between threads because Parsers are
- * all immutable and therad-safe.
+ * all immutable and thread-safe.
  *
  * @see Parsers
  */
@@ -82,6 +84,7 @@ public interface Parser {
      *     uuid literal</a>.</li>
      *
      * </ul>
+     * @param pbr parse the next value from this Parseable. Must not be null.
      *
      *
      * @throws EdnIOException
@@ -146,7 +149,7 @@ public interface Parser {
          * returned by the parser.
          */
         public static final Tag BIG_DECIMAL_TAG = newTag(
-            "us.bpsm.edn-java", "BigDecimal");
+                "us.bpsm.edn-java", "BigDecimal");
 
         /**
          * Floating point literals not marked by a trailing "M" are
@@ -159,7 +162,7 @@ public interface Parser {
          * the parser.
          */
         public static final Tag DOUBLE_TAG = newTag(
-            "us.bpsm.edn-java", "Double");
+                "us.bpsm.edn-java", "Double");
 
         /**
          * Integer literals marked by a trailing "N", and those not so
@@ -173,7 +176,7 @@ public interface Parser {
          * the parser.
          */
         public static final Tag BIG_INTEGER_TAG = newTag(
-            "us.bpsm.edn-java", "BigInteger");
+                "us.bpsm.edn-java", "BigInteger");
 
         /**
          * Integer literals which lie inside the range of a {@link
@@ -187,7 +190,7 @@ public interface Parser {
          * parser.
          */
         public static final Tag LONG_TAG = newTag(
-            "us.bpsm.edn-java", "Long");
+                "us.bpsm.edn-java", "Long");
 
         /**
          * Provide a {@link CollectionBuilder.Factory} to receive the
@@ -196,6 +199,8 @@ public interface Parser {
          * <p>The default implementation returns an unmodifiable view
          * of a {@link java.util.List} that does not implement {@link
          * java.util.RandomAccess}.
+         *
+         * @return a CollectionBuilder.Factory for building lists; never null.
          */
         public CollectionBuilder.Factory getListFactory();
 
@@ -205,7 +210,9 @@ public interface Parser {
          *
          * <p>The default implementation returns an unmodifiable view
          * of a {@link java.util.List} that implements {@link
-         * java.util.RadomAccess}.</p>
+         * java.util.RandomAccess}.</p>
+         *
+         * @return a CollectionBuilder.Factory for building vectors; never null.
          */
         public CollectionBuilder.Factory getVectorFactory();
 
@@ -215,6 +222,8 @@ public interface Parser {
          *
          * <p>The default implementation returns an unmodifiable view
          * of a {@link java.util.Set} (hashed, not sorted).
+         *
+         * @return a CollectionBuilder.Factory for building sets; never null.
          */
         public CollectionBuilder.Factory getSetFactory();
 
@@ -224,6 +233,8 @@ public interface Parser {
          *
          * <p>The default implementation returns an unmodifiable view
          * of a {@link java.util.Map} (hashed, not sorted).
+         *
+         * @return a CollectionBuilder.Factory for building maps; never null.
          */
         public CollectionBuilder.Factory getMapFactory();
 

--- a/src/main/java/us/bpsm/edn/parser/Parsers.java
+++ b/src/main/java/us/bpsm/edn/parser/Parsers.java
@@ -44,23 +44,23 @@ import us.bpsm.edn.parser.Parser.Config.Builder;
  *     {@link #newParseable(Readable)}.</li>
  *
  * <li>Use {@link Parser#nextValue(Parseable)} to get
- *     the edn values contained in your Parseables</li>
+ *     the edn values contained in your Parseable</li>
  *
  * </ol>
  */
 public class Parsers {
 
     static final CollectionBuilder.Factory DEFAULT_LIST_FACTORY =
-        new DefaultListFactory();
+            new DefaultListFactory();
 
     static final CollectionBuilder.Factory DEFAULT_VECTOR_FACTORY =
-        new DefaultVectorFactory();
+            new DefaultVectorFactory();
 
     static final CollectionBuilder.Factory DEFAULT_SET_FACTORY =
-        new DefaultSetFactory();
+            new DefaultSetFactory();
 
     static final CollectionBuilder.Factory DEFAULT_MAP_FACTORY =
-        new DefaultMapFactory();
+            new DefaultMapFactory();
 
     static final TagHandler INSTANT_TO_DATE = new InstantToDate();
 
@@ -104,9 +104,11 @@ public class Parsers {
     /**
      * Create a new {@link Parseable} wrapping the given {@link
      * CharSequence}.
-
+     *
      * <p>The {@link java.io.Closeable#close()} method of the resulting
      * Parseable is a no-op.
+     *
+     * @param cs must not be null.
      *
      * @return a Parseable, never null.
      */
@@ -120,7 +122,7 @@ public class Parsers {
             public int read() throws IOException {
                 try {
                     return cs.charAt(i++);
-                } catch (IndexOutOfBoundsException _) {
+                } catch (IndexOutOfBoundsException suppressed) {
                     return Parseable.END_OF_INPUT;
                 }
             }
@@ -136,7 +138,9 @@ public class Parsers {
      *
      * <p>The {@link java.io.Closeable#close()} method of the
      * resulting Parseable closes the {@code r} if {@code r} is itself
-     * Closeable.
+     * Closable.
+     * @param r a Readable which must not be null.
+     * @return a Parseable over the given Readable.
      */
     public static Parseable newParseable(final Readable r) {
         return new Parseable() {
@@ -257,7 +261,7 @@ public class Parsers {
             private void checkState() {
                 if (used) {
                     throw new IllegalStateException(
-                        "Builder is single-use. Not usable after build()");
+                            "Builder is single-use. Not usable after build()");
                 }
             }
         };

--- a/src/main/java/us/bpsm/edn/parser/Scanner.java
+++ b/src/main/java/us/bpsm/edn/parser/Scanner.java
@@ -19,15 +19,15 @@ public interface Scanner {
      * The next token read from the given {@link Parseable} may be any of the
      * members of {@link Token} or instances of the Java classes used to
      * represent atomic values recognized by Scanner.
-     * 
+     *
      * <p>
      * The value {@link Token#END_OF_INPUT} marks the end of input, indicating
      * that the underlying {@link Parseable} has been fully consumed.
-     * 
+     *
      * <p>
      * In addition to the members of {@link Token}, {@code nextToken(…)} may
      * return any of the following:
-     * 
+     *
      * <ul>
      * <li>A {@link String} with the contents of a string literal.</li>
      * <li>A {@link Character} for a character literal.</li>
@@ -46,13 +46,14 @@ public interface Scanner {
      * <li>A {@link Tag} indicating that the next value parsed from the TokenSeq
      * should be transformed by a function associated with this Tag.</li>
      * </ul>
-     * 
+     * @param pbr a Parseable to read the next token from; must not be null.
+     *
      * @throws EdnIOException
      *             if the underlying Parseable throws an IOException.
      * @throws EdnSyntaxException
      *             if the contents of the underlying Parseable violates the
      *             syntax of edn.
-     * 
+     *
      * @return the next token read from the {@link Parseable} (never
      *         {@code null}).
      */

--- a/src/main/java/us/bpsm/edn/parser/ScannerImpl.java
+++ b/src/main/java/us/bpsm/edn/parser/ScannerImpl.java
@@ -40,7 +40,6 @@ class ScannerImpl implements Scanner {
      * Scanner may throw an IOException during construction, in which case
      * an attempt will be made to close Reader cleanly.
      * @param cfg this scanner's configuration, never null.
-     * @throws IOException
      */
     ScannerImpl(Parser.Config cfg) {
         if (cfg == null) {
@@ -178,8 +177,8 @@ class ScannerImpl implements Scanner {
             return readCharacterLiteral(pbr);
         default:
             throw new EdnSyntaxException(
-                String.format("Unexpected character '%c', \\"+"u%04x",
-                    (char)curr, curr));
+                    String.format("Unexpected character '%c', \\"+"u%04x",
+                            (char)curr, curr));
         }
     }
 
@@ -198,7 +197,7 @@ class ScannerImpl implements Scanner {
     }
 
     private Object readSymbolOrNumber(int curr, Parseable pbr)
-        throws IOException {
+            throws IOException {
         int peek = pbr.read();
         if (peek == END) {
             return readSymbol(curr, pbr);
@@ -218,19 +217,19 @@ class ScannerImpl implements Scanner {
     }
 
     private Object readSymbolOrTrue(int curr, Parseable pbr)
-        throws IOException {
+            throws IOException {
         Symbol sym = readSymbol(curr, pbr);
         return TRUE_SYMBOL.equals(sym) ? true : sym;
     }
 
     private Object readSymbolOrNil(int curr, Parseable pbr)
-        throws IOException {
+            throws IOException {
         Symbol sym = readSymbol(curr, pbr);
         return NIL_SYMBOL.equals(sym) ? Token.NIL : sym;
     }
 
     private Object readSymbolOrFalse(int curr, Parseable pbr)
-        throws IOException {
+            throws IOException {
         Symbol sym = readSymbol(curr, pbr);
         return FALSE_SYMBOL.equals(sym) ? false : sym;
     }
@@ -267,11 +266,11 @@ class ScannerImpl implements Scanner {
         int curr = pbr.read();
         if (curr == END) {
             throw new EdnSyntaxException(
-                "Unexpected end of input following '\'");
+                    "Unexpected end of input following '\'");
         } else if (isWhitespace((char)curr) && curr != ',') {
             throw new EdnSyntaxException(
-                "A backslash introducing character literal must not be "+
-                "immediately followed by whitespace.");
+                    "A backslash introducing character literal must not be "+
+                    "immediately followed by whitespace.");
         }
         StringBuilder b = new StringBuilder();
         do {
@@ -320,7 +319,7 @@ class ScannerImpl implements Scanner {
             // fall through
         default:
             throw new EdnSyntaxException(
-                "The character \\"+ name +" was not recognized.");
+                    "The character \\"+ name +" was not recognized.");
         }
     }
 
@@ -331,7 +330,7 @@ class ScannerImpl implements Scanner {
             switch (curr) {
             case END:
                 throw new EdnSyntaxException(
-                    "Unexpected end of input in string literal");
+                        "Unexpected end of input in string literal");
             case '"':
                 return b.toString();
             case '\\':
@@ -339,7 +338,7 @@ class ScannerImpl implements Scanner {
                 switch (curr) {
                 case END:
                     throw new EdnSyntaxException(
-                        "Unexpected end of input in string literal");
+                            "Unexpected end of input in string literal");
                 case 'b':
                     b.append('\b');
                     break;
@@ -366,7 +365,7 @@ class ScannerImpl implements Scanner {
                     break;
                 default:
                     throw new EdnSyntaxException("Unsupported '"+ ((char)curr)
-                        +"' escape in string");
+                            +"' escape in string");
                 }
                 break;
             default:
@@ -401,11 +400,11 @@ class ScannerImpl implements Scanner {
                 curr = pbr.read();
                 if (curr == END) {
                     throw new EdnSyntaxException(
-                        "Unexpected end of input in numeric literal");
+                            "Unexpected end of input in numeric literal");
                 }
                 if (!(curr == '-' || curr == '+' || isDigit((char)curr))) {
                     throw new EdnSyntaxException(
-                        "Not a number: '"+ digits + ((char)curr) +"'.");
+                            "Not a number: '"+ digits + ((char)curr) +"'.");
                 }
                 do {
                     digits.append((char)curr);
@@ -420,7 +419,7 @@ class ScannerImpl implements Scanner {
 
             if (curr != END && !separatesTokens((char)curr)) {
                 throw new EdnSyntaxException(
-                    "Not a number: '"+ digits + ((char)curr) +"'.");
+                        "Not a number: '"+ digits + ((char)curr) +"'.");
             }
             unread(pbr, curr);
 
@@ -439,7 +438,7 @@ class ScannerImpl implements Scanner {
 
             if (curr != END && !separatesTokens((char)curr)) {
                 throw new EdnSyntaxException(
-                    "Not a number: '"+ digits + ((char)curr) +"'.");
+                        "Not a number: '"+ digits + ((char)curr) +"'.");
             }
             unread(pbr, curr);
 
@@ -468,7 +467,7 @@ class ScannerImpl implements Scanner {
     private Symbol readSymbol(int curr, Parseable pbr) throws IOException {
         if (curr == END) {
             throw new EdnSyntaxException(
-                "Unexpected end of input while reading an identifier");
+                    "Unexpected end of input while reading an identifier");
         }
         StringBuilder b = new StringBuilder();
         int n = 0;

--- a/src/main/java/us/bpsm/edn/printer/Printer.java
+++ b/src/main/java/us/bpsm/edn/printer/Printer.java
@@ -1,6 +1,9 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn.printer;
 
+import us.bpsm.edn.EdnException;
+import us.bpsm.edn.EdnIOException;
+
 /**
  * A Printer knows how to print edn values in edn syntax to an
  * underlying stream of characters. Use {@link Printers} to create new
@@ -67,7 +70,7 @@ public interface Printer {
         /**
          * Implementations which may provoke an
          * {@link java.io.IOException} should wrapping it in an
-         * {@link us.bpsm.edn.EdnIOException} before rethrowing it.
+         * {@link us.bpsm.edn.EdnIOException} before re-throwing it.
          *
          * @param self some edn value to be printed.
          * @param printer the printer that called us, giving us access to

--- a/src/main/java/us/bpsm/edn/printer/Printers.java
+++ b/src/main/java/us/bpsm/edn/printer/Printers.java
@@ -69,7 +69,7 @@ public class Printers {
      * @return A string in edn syntax. Not null, not empty.
      */
     public static String printString(final Protocol<Printer.Fn<?>> fns,
-                                     Object ednValue) {
+            Object ednValue) {
         StringBuilder sb = new StringBuilder();
         newPrinter(fns, sb).printValue(ednValue);
         return sb.toString();
@@ -89,7 +89,7 @@ public class Printers {
      * @return a Printer, never null.
      */
     public static Printer newPrinter(final Protocol<Printer.Fn<?>> fns,
-                                     final Appendable out) {
+            final Appendable out) {
         return new Printer() {
             int softspace = 0;
 
@@ -133,7 +133,7 @@ public class Printers {
             public Printer printValue(Object ednValue) {
                 @SuppressWarnings("unchecked")
                 Printer.Fn<Object> printFn = (Printer.Fn<Object>)
-                    fns.lookup(getClassOrNull(ednValue));
+                fns.lookup(getClassOrNull(ednValue));
                 if (printFn == null) {
                     throw new EdnException(String.format(
                             "Don't know how to write '%s' of type '%s'",
@@ -159,7 +159,8 @@ public class Printers {
 
     /**
      * Returns a {@link us.bpsm.edn.protocols.Protocol.Builder}
-     * preconfigured knowing how to print classes known to end-java:
+     * configured to produce a Protocol which knows how to print
+     * these types of values:
      *
      * <ul>
      * <li>{@link BigDecimal}</li>
@@ -182,35 +183,37 @@ public class Printers {
      * <li>{@link Symbol}</li>
      * <li>{@link Tag}</li>
      * <li>{@link TaggedValue}</li>
-     * <li>{@link Timestamp} (as {@code #inst})</li>
+     * <li>{@link java.sql.Timestamp} (as {@code #inst})</li>
      * <li>{@link UUID} (as {@code #uuid})</li>
      * </ul>
+     * @return a Protocol.Builder initialized with the default implementations
+     *         for printing.
      */
     public static Protocol.Builder<Printer.Fn<?>> defaultProtocolBuilder() {
         return Protocols.<Printer.Fn<?>>builder("print")
-            .put(null, writeNullFn())
-            .put(BigDecimal.class, writeBigDecimalFn())
-            .put(BigInteger.class, writeBigIntegerFn())
-            .put(Boolean.class, writeBooleanFn())
-            .put(Byte.class, writeLongValueFn())
-            .put(CharSequence.class, writeCharSequenceFn())
-            .put(Character.class, writeCharacterFn())
-            .put(Date.class, writeDateFn())
-            .put(Double.class, writeDoubleValueFn())
-            .put(Float.class, writeDoubleValueFn())
-            .put(GregorianCalendar.class, writeCalendarFn())
-            .put(Integer.class, writeLongValueFn())
-            .put(Keyword.class, writeKeywordFn())
-            .put(List.class, writeListFn())
-            .put(Long.class, writeLongValueFn())
-            .put(Map.class, writeMapFn())
-            .put(Set.class, writeSetFn())
-            .put(Short.class, writeLongValueFn())
-            .put(Symbol.class, writeSymbolFn())
-            .put(Tag.class, writeTagFn())
-            .put(TaggedValue.class, writeTaggedValueFn())
-            .put(Timestamp.class, writeTimestampFn())
-            .put(UUID.class, writeUuidFn());
+                .put(null, writeNullFn())
+                .put(BigDecimal.class, writeBigDecimalFn())
+                .put(BigInteger.class, writeBigIntegerFn())
+                .put(Boolean.class, writeBooleanFn())
+                .put(Byte.class, writeLongValueFn())
+                .put(CharSequence.class, writeCharSequenceFn())
+                .put(Character.class, writeCharacterFn())
+                .put(Date.class, writeDateFn())
+                .put(Double.class, writeDoubleValueFn())
+                .put(Float.class, writeDoubleValueFn())
+                .put(GregorianCalendar.class, writeCalendarFn())
+                .put(Integer.class, writeLongValueFn())
+                .put(Keyword.class, writeKeywordFn())
+                .put(List.class, writeListFn())
+                .put(Long.class, writeLongValueFn())
+                .put(Map.class, writeMapFn())
+                .put(Set.class, writeSetFn())
+                .put(Short.class, writeLongValueFn())
+                .put(Symbol.class, writeSymbolFn())
+                .put(Tag.class, writeTagFn())
+                .put(TaggedValue.class, writeTaggedValueFn())
+                .put(Timestamp.class, writeTimestampFn())
+                .put(UUID.class, writeUuidFn());
     }
 
     /**

--- a/src/main/java/us/bpsm/edn/protocols/Protocol.java
+++ b/src/main/java/us/bpsm/edn/protocols/Protocol.java
@@ -5,12 +5,15 @@ package us.bpsm.edn.protocols;
  * A Protocol is a thread-safe immutable mapping from classes to
  * values of some type {@code F}. Each Protocol is created by a {@link
  * Protocol.Builder}.
+ * @param <F> whatever kind of thing you'd like to map to. Generally this will
+ * be some class or interface representing a function.
  */
 public interface Protocol<F> {
 
     /**
      * The name of this protocol. (This is intended to support
      * debugging scenarios.)
+     * @return The name of this protocol; not null.
      */
     String name();
 
@@ -19,7 +22,8 @@ public interface Protocol<F> {
      *
      * <p>If the Protocol does not contain a mapping for exactly
      * {@code selfClass}, then try {@code selfClass}'s supertypes in
-     * <a href="">C3</a> linearized order, only returning {@code null}
+     * <a href="http://en.wikipedia.org/wiki/C3_linearization">C3</a>
+     * linearized order, only returning {@code null}
      * when all sueprtypes have been tried without finding a match.
      *
      * <p>{@code selfClass} may be {@code null}, in which case return
@@ -38,6 +42,8 @@ public interface Protocol<F> {
      * A single-use builder for Protocol. This builder is not intended
      * for use from more than once thread. Use
      * {@link Protocols#builder(String)} to obtain new instances.
+     * @param <F> whatever kind of thing you'd like to map to. Generally this
+     *            will be some class or interface representing a function.
      */
     public interface Builder<F> {
 

--- a/src/main/java/us/bpsm/edn/protocols/Protocols.java
+++ b/src/main/java/us/bpsm/edn/protocols/Protocols.java
@@ -19,7 +19,7 @@ public class Protocols {
 
     static final String NO_MODIFY_MSG =
             "This builder is single-use and may not be modified after " +
-            "the Protocol has been built.";
+                    "the Protocol has been built.";
 
     static final String MUST_HAVE_NAME =
             "Each Protocol must have a name";
@@ -36,7 +36,7 @@ public class Protocols {
      * the given name.
      *
      * @param name not null.
-     *
+     * @param <F> the type of the returned Builder
      * @return an empty {@code Protocol.Builder}, never null.
      */
     public static <F> Protocol.Builder<F> builder(final String name) {

--- a/src/test/java/us/bpsm/edn/SerializabilityTest.java
+++ b/src/test/java/us/bpsm/edn/SerializabilityTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 
 public class SerializabilityTest {
@@ -23,14 +24,16 @@ public class SerializabilityTest {
         return bytesOut.toByteArray();
     }
 
-    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+    private static Object deserialize(byte[] bytes)
+      throws IOException, ClassNotFoundException {
         ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
         ObjectInputStream objectsIn = new ObjectInputStream(bytesIn);
         return objectsIn.readObject();
     }
 
     @Test
-    public void testSerializability() throws IOException, ClassNotFoundException {
+    public void testSerializability()
+      throws IOException, ClassNotFoundException {
         Parseable pbr = Parsers.newParseable(IOUtil.stringFromResource(
           "us/bpsm/edn/serializability.edn"));
         Parser parser = Parsers.newParser(Parsers.defaultConfiguration());
@@ -38,6 +41,16 @@ public class SerializabilityTest {
         assertNotEquals(Parser.END_OF_INPUT, expected);
         List<Object> result = (List<Object>) deserialize(serialize(expected));
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testKeywordIdentity()
+      throws IOException, ClassNotFoundException {
+        Parseable pbr = Parsers.newParseable(":keyword");
+        Parser parser = Parsers.newParser(Parsers.defaultConfiguration());
+        Keyword expected = (Keyword) parser.nextValue(pbr);
+        Keyword result = (Keyword) deserialize(serialize(expected));
+        assertSame(expected, result);
     }
 
 }

--- a/src/test/java/us/bpsm/edn/SerializabilityTest.java
+++ b/src/test/java/us/bpsm/edn/SerializabilityTest.java
@@ -1,0 +1,43 @@
+package us.bpsm.edn;
+
+import org.junit.Test;
+import us.bpsm.edn.parser.IOUtil;
+import us.bpsm.edn.parser.Parseable;
+import us.bpsm.edn.parser.Parser;
+import us.bpsm.edn.parser.Parsers;
+
+import java.io.*;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+
+public class SerializabilityTest {
+
+    private static byte[] serialize(Object o) throws IOException {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        ObjectOutputStream objectsOut = new ObjectOutputStream(bytesOut);
+        objectsOut.writeObject(o);
+        objectsOut.close();
+        return bytesOut.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
+        ObjectInputStream objectsIn = new ObjectInputStream(bytesIn);
+        return objectsIn.readObject();
+    }
+
+    @Test
+    public void testSerializability() throws IOException, ClassNotFoundException {
+        Parseable pbr = Parsers.newParseable(IOUtil.stringFromResource(
+          "us/bpsm/edn/serializability.edn"));
+        Parser parser = Parsers.newParser(Parsers.defaultConfiguration());
+        Object expected = parser.nextValue(pbr);
+        assertNotEquals(Parser.END_OF_INPUT, expected);
+        List<Object> result = (List<Object>) deserialize(serialize(expected));
+        assertEquals(expected, result);
+    }
+
+}

--- a/src/test/java/us/bpsm/edn/performance/CaliperTest.java
+++ b/src/test/java/us/bpsm/edn/performance/CaliperTest.java
@@ -8,8 +8,14 @@ import us.bpsm.edn.printer.Printers;
 import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
 
+/**
+ * A basic test of parsing and printing speed.
+ */
 public class CaliperTest extends SimpleBenchmark {
 
+    /**
+     * @param reps number of times to parse the test string.
+     */
     @SuppressWarnings("unused")
     public void timeStringParsing(int reps) {
         Parseable r = Parsers.newParseable(PerformanceTest.ednString);
@@ -19,6 +25,9 @@ public class CaliperTest extends SimpleBenchmark {
         }
     }
 
+    /**
+     * @param reps number of times to call print the test data.
+     */
     @SuppressWarnings("unused")
     public void timeStringWriting(int reps) {
         for (int i=0; i<reps; i++) {
@@ -27,7 +36,7 @@ public class CaliperTest extends SimpleBenchmark {
     }
 
     /**
-     * @param args
+     * @param args ignored.
      */
     public static void main(String[] args) {
         new CaliperTest().run();

--- a/src/test/java/us/bpsm/edn/performance/CombinedBenchmark.java
+++ b/src/test/java/us/bpsm/edn/performance/CombinedBenchmark.java
@@ -1,8 +1,14 @@
 package us.bpsm.edn.performance;
 
 
+/**
+ * Combined parsing benchmark over all test inputs.
+ */
 public class CombinedBenchmark extends ABenchmark {
 
+    /**
+     * @param reps number of times to parse each of the test documents.
+     */
     public void time_combined(int reps) {
         parse(reps, "large-keyword-map.edn");
         parse(reps, "large-symbol-map.edn");
@@ -31,6 +37,9 @@ public class CombinedBenchmark extends ABenchmark {
         parse(reps, "vector-tree.edn");
     }
 
+    /**
+     * @param args ignored
+     */
     public static void main(String[] args) {
         new CombinedBenchmark().run();
     }

--- a/src/test/resources/us/bpsm/edn/serializability.edn
+++ b/src/test/resources/us/bpsm/edn/serializability.edn
@@ -1,0 +1,18 @@
+[:keyword
+ :keyword/with-namespace
+ symbol
+ symbol/with-namespace
+ nil
+ true
+ false
+ "string literal"
+ 1
+ 1N
+ 1.0
+ 1.0M
+ \A
+ #tagged "value"
+ #tagged/with-namespace "value"
+ #{"some" "set"}
+ {"some" "map"}
+ ("a" "list" "of" "things")]


### PR DESCRIPTION
This addresses a use-case where Apache Spark configuration is stored as edn but needs to be distributed between machines via Java Serialization after parsing because that's the way Spark wants to work.
