### PR TITLE
issue43: Make parsed EDN values Serializable

### DIFF
--- a/src/main/java/us/bpsm/edn/Keyword.java
+++ b/src/main/java/us/bpsm/edn/Keyword.java
@@ -1,6 +1,11 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
 import static us.bpsm.edn.Symbol.newSymbol;
 
 /**
@@ -19,7 +24,7 @@ import static us.bpsm.edn.Symbol.newSymbol;
  * k.toString()  => ":foo/bar"}
  * </pre>
  */
-public final class Keyword implements Named, Comparable<Keyword> {
+public final class Keyword implements Named, Comparable<Keyword>, Serializable {
     private final Symbol sym;
 
     /** {@inheritDoc} */
@@ -91,4 +96,23 @@ public final class Keyword implements Named, Comparable<Keyword> {
 
     private static final Interner<Symbol, Keyword> INTERNER = new Interner<Symbol, Keyword>();
 
+    private Object writeReplace() {
+        return new SerializationProxy(sym);
+    }
+
+    private void readObject(ObjectInputStream stream)
+      throws InvalidObjectException {
+        throw new InvalidObjectException("only proxy can be serialized");
+    }
+
+    private static class SerializationProxy implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final Symbol sym;
+        private SerializationProxy(Symbol sym) {
+            this.sym = sym;
+        }
+        private Object readResolve() throws ObjectStreamException {
+            return newKeyword(sym);
+        }
+    }
 }

--- a/src/main/java/us/bpsm/edn/Symbol.java
+++ b/src/main/java/us/bpsm/edn/Symbol.java
@@ -5,12 +5,14 @@ import static us.bpsm.edn.util.CharClassify.isDigit;
 import static us.bpsm.edn.util.CharClassify.symbolStart;
 import us.bpsm.edn.util.CharClassify;
 
+import java.io.Serializable;
+
 /**
  * A Symbol is {@linkplain Named}. Additionally it obeys the syntactic
  * restrictions defined for
  * <a href="https://github.com/edn-format/edn#symbols">edn Symbols</a>.
  */
-public final class Symbol implements Named, Comparable<Symbol> {
+public final class Symbol implements Named, Comparable<Symbol>, Serializable {
 
     private final String prefix;
     private final String name;

--- a/src/main/java/us/bpsm/edn/Tag.java
+++ b/src/main/java/us/bpsm/edn/Tag.java
@@ -1,6 +1,8 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.Serializable;
+
 import static us.bpsm.edn.Symbol.newSymbol;
 
 /**
@@ -18,7 +20,7 @@ import static us.bpsm.edn.Symbol.newSymbol;
  * t.toString()  => "#foo/bar"}
  * </pre>
  */
-public final class Tag implements Named, Comparable<Tag> {
+public final class Tag implements Named, Comparable<Tag>, Serializable {
     private final Symbol sym;
 
     /** {@inheritDoc} */

--- a/src/main/java/us/bpsm/edn/TaggedValue.java
+++ b/src/main/java/us/bpsm/edn/TaggedValue.java
@@ -1,11 +1,13 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn;
 
+import java.io.Serializable;
+
 /**
  * A Tagged value that received no specific handling because the Parser
  * was not configured with a handler for its tag.
  */
-public final class TaggedValue {
+public final class TaggedValue implements Serializable {
     private final Tag tag;
     private final Object value;
 

--- a/src/main/java/us/bpsm/edn/parser/DefaultListFactory.java
+++ b/src/main/java/us/bpsm/edn/parser/DefaultListFactory.java
@@ -1,6 +1,7 @@
 // (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 package us.bpsm.edn.parser;
 
+import java.io.Serializable;
 import java.util.*;
 
 final class DefaultListFactory implements CollectionBuilder.Factory {
@@ -17,7 +18,7 @@ final class DefaultListFactory implements CollectionBuilder.Factory {
     }
 }
 
-final class DelegatingList<E> extends AbstractList<E> {
+final class DelegatingList<E> extends AbstractList<E> implements Serializable {
     final List<E> delegate;
 
     DelegatingList(List<E> delegate) {

--- a/src/test/java/us/bpsm/edn/SerializabilityTest.java
+++ b/src/test/java/us/bpsm/edn/SerializabilityTest.java
@@ -1,0 +1,56 @@
+package us.bpsm.edn;
+
+import org.junit.Test;
+import us.bpsm.edn.parser.IOUtil;
+import us.bpsm.edn.parser.Parseable;
+import us.bpsm.edn.parser.Parser;
+import us.bpsm.edn.parser.Parsers;
+
+import java.io.*;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+
+
+public class SerializabilityTest {
+
+    private static byte[] serialize(Object o) throws IOException {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        ObjectOutputStream objectsOut = new ObjectOutputStream(bytesOut);
+        objectsOut.writeObject(o);
+        objectsOut.close();
+        return bytesOut.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes)
+      throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
+        ObjectInputStream objectsIn = new ObjectInputStream(bytesIn);
+        return objectsIn.readObject();
+    }
+
+    @Test
+    public void testSerializability()
+      throws IOException, ClassNotFoundException {
+        Parseable pbr = Parsers.newParseable(IOUtil.stringFromResource(
+          "us/bpsm/edn/serializability.edn"));
+        Parser parser = Parsers.newParser(Parsers.defaultConfiguration());
+        Object expected = parser.nextValue(pbr);
+        assertNotEquals(Parser.END_OF_INPUT, expected);
+        List<Object> result = (List<Object>) deserialize(serialize(expected));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testKeywordIdentity()
+      throws IOException, ClassNotFoundException {
+        Parseable pbr = Parsers.newParseable(":keyword");
+        Parser parser = Parsers.newParser(Parsers.defaultConfiguration());
+        Keyword expected = (Keyword) parser.nextValue(pbr);
+        Keyword result = (Keyword) deserialize(serialize(expected));
+        assertSame(expected, result);
+    }
+
+}

--- a/src/test/resources/us/bpsm/edn/serializability.edn
+++ b/src/test/resources/us/bpsm/edn/serializability.edn
@@ -1,0 +1,18 @@
+[:keyword
+ :keyword/with-namespace
+ symbol
+ symbol/with-namespace
+ nil
+ true
+ false
+ "string literal"
+ 1
+ 1N
+ 1.0
+ 1.0M
+ \A
+ #tagged "value"
+ #tagged/with-namespace "value"
+ #{"some" "set"}
+ {"some" "map"}
+ ("a" "list" "of" "things")]


### PR DESCRIPTION
For some use cases it is desirable that the Values produced by parsing EDN text be able to participate in Java Serialization.

This branch teaches Keyword, Symbol, Tag, TaggedValue and DelegatingList to be Serializable.

The case of Keyword is complicated by the fact that Keyword instances are controlled.  We use a SerializationProxy which implements readResolve() by calling newKeyword() so as to maintain the invariant:

    Symbol s1 = ..., s2 = ...;
    Keyword kw1 = Keyword.newKeyword(s1);
    Keyword kw2 = Keyword.newKeyword(s2);

    (s1.equals(s2)) == (kw1 == kw2)

That is, any two keywords are *identical* if and only if they were created from any two *equal* Symbols.

Note that newKeyword(prefix, name) is exactly equivalent to newKeyword(newSymbol(prefix, name)).