### PR TITLE
Define a stable automatic module name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>us.bpsm</groupId>
   <artifactId>edn-java</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
   <packaging>jar</packaging>
   <name>EDN Java</name>
   <description>
@@ -67,6 +67,18 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>us.bpsm.edn</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
@brunchboy would like to modularize the project [lib-carabiner](https://github.com/Deep-Symmetry/lib-carabiner) but is unable to do so because edn-java does not define an automatic module name. See [this article](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) for a very good explanation of why this is necessary. All the other `lib-carabiner` dependencies already do this, so as soon as edn-java does, it will be possible.

This pull request sets `us.bpsm.edn` as the automatic module name, which makes sense as it is likely the module name you will use if you ever decide to modularize this project itself.

Thanks for considering this change.